### PR TITLE
Small changes

### DIFF
--- a/arcdps_collector/GUI.cpp
+++ b/arcdps_collector/GUI.cpp
@@ -41,7 +41,7 @@ void GUI::Display()
 	}
 
 	ImGui::SetNextWindowSize(ImVec2(600, 250), ImGuiCond_FirstUseEver);
-	if (ImGui::Begin("Event Collector", &mDisplayed) == true)
+	if (ImGui::Begin("Event Collector", &mDisplayed, ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav) == true)
 	{
 		ImGui::Text("%zu events collected", mCollector.GetEventCount());
 

--- a/arcdps_mock/main.cpp
+++ b/arcdps_mock/main.cpp
@@ -334,11 +334,6 @@ int Run(const char* pModulePath, const char* pMockFilePath)
 		// Show options window (mirror of arcdps options)
 		{
 			ImGui::Begin("Options", nullptr, ImGuiWindowFlags_NoCollapse);
-			ImGui::Checkbox("Logs", &combatMock->showLog);
-			if (TEST_MODULE_EXPORTS.options_end != nullptr)
-			{
-				TEST_MODULE_EXPORTS.options_end();
-			}
 
 			if (TEST_MODULE_EXPORTS.options_windows != nullptr) {
 				TEST_MODULE_EXPORTS.options_windows("skills");
@@ -349,6 +344,13 @@ int Run(const char* pModulePath, const char* pMockFilePath)
 				TEST_MODULE_EXPORTS.options_windows("Errors");
 				TEST_MODULE_EXPORTS.options_windows(nullptr);
 			}
+			
+			ImGui::Checkbox("Logs", &combatMock->showLog);
+			if (TEST_MODULE_EXPORTS.options_end != nullptr)
+			{
+				TEST_MODULE_EXPORTS.options_end();
+			}
+			
 			ImGui::End();
 		}
 
@@ -387,6 +389,7 @@ int Run(const char* pModulePath, const char* pMockFilePath)
 
 	ImGui_ImplDX9_Shutdown();
 	ImGui_ImplWin32_Shutdown();
+
 	ImGui::DestroyContext();
 
 	CleanupDeviceD3D();

--- a/arcdps_mock/main.cpp
+++ b/arcdps_mock/main.cpp
@@ -336,12 +336,13 @@ int Run(const char* pModulePath, const char* pMockFilePath)
 			ImGui::Begin("Options", nullptr, ImGuiWindowFlags_NoCollapse);
 
 			if (TEST_MODULE_EXPORTS.options_windows != nullptr) {
+				TEST_MODULE_EXPORTS.options_windows("bufftable");
+				TEST_MODULE_EXPORTS.options_windows("squad");
+				TEST_MODULE_EXPORTS.options_windows("dps");
 				TEST_MODULE_EXPORTS.options_windows("skills");
 				TEST_MODULE_EXPORTS.options_windows("metrics");
-				TEST_MODULE_EXPORTS.options_windows("dps");
+				TEST_MODULE_EXPORTS.options_windows("error");
 				TEST_MODULE_EXPORTS.options_windows("log");
-				TEST_MODULE_EXPORTS.options_windows("bufftable");
-				TEST_MODULE_EXPORTS.options_windows("Errors");
 				TEST_MODULE_EXPORTS.options_windows(nullptr);
 			}
 			


### PR DESCRIPTION
arcpd_collector:
- window is not autofocus and is inaccessable by pressing TAB

arcdps_mock:
- moved option_windows calls before option_end call (like in reality)
- added `squad` to option_windows calls
- renamed `Errors` to `error` (was renamed in arcdps as well)