### PR TITLE
build and save dll/exe in github actions

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -33,5 +33,5 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
       
-    - run: dir
+    - run: cd x64; dir
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,35 @@
+name: MSBuild
+
+on: [push]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      
+    - run: dir
+

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -13,10 +13,6 @@ jobs:
     strategy:
       matrix:
         mode: ["Debug", "Release"]
-        
-    # Configuration type to build.
-    env:
-      BUILD_CONFIGURATION: ${{ matrix.mode }}
 
     steps:
     - uses: actions/checkout@v2
@@ -34,7 +30,7 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: msbuild /m /p:Configuration=${{matrix.mode}} ${{env.SOLUTION_FILE_PATH}}
       
     - name: Archive files
       uses: actions/upload-artifact@v2
@@ -44,4 +40,3 @@ jobs:
           x64/${{ matrix.mode }}/*.exe
           x64/${{ matrix.mode }}/*.dll
           x64/${{ matrix.mode }}/*.pdb
-

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -9,7 +9,7 @@ env:
   # Configuration type to build.
   # You can convert this to a build matrix if you need coverage of multiple configuration types.
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-  BUILD_CONFIGURATION: Release
+  BUILD_CONFIGURATION: Debug
 
 jobs:
   build:
@@ -33,5 +33,12 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
       
-    - run: cd x64; dir
+    - name: Archive files
+      uses: actions/upload-artifact@v2
+      with:
+        name: arcdps_mock
+        path: |
+          x64/Debug/*.exe
+          x64/Debug/*.dll
+          x64/Debug/*.pdb
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -6,14 +6,17 @@ env:
   # Path to the solution file relative to the root of the project.
   SOLUTION_FILE_PATH: .
 
-  # Configuration type to build.
-  # You can convert this to a build matrix if you need coverage of multiple configuration types.
-  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-  BUILD_CONFIGURATION: Debug
-
 jobs:
   build:
     runs-on: windows-latest
+    
+    strategy:
+      matrix:
+        mode: ["Debug", "Release"]
+        
+    # Configuration type to build.
+    env:
+      BUILD_CONFIGURATION: ${{ matrix.mode }}
 
     steps:
     - uses: actions/checkout@v2
@@ -36,9 +39,9 @@ jobs:
     - name: Archive files
       uses: actions/upload-artifact@v2
       with:
-        name: arcdps_mock
+        name: arcdps_mock_${{ matrix.mode }}
         path: |
-          x64/Debug/*.exe
-          x64/Debug/*.dll
-          x64/Debug/*.pdb
+          x64/${{ matrix.mode }}/*.exe
+          x64/${{ matrix.mode }}/*.dll
+          x64/${{ matrix.mode }}/*.pdb
 


### PR DESCRIPTION
I have added a github actions script to automatic build and save the exe and dll (both in Debug).

Already run action on my repo: https://github.com/knoxfighter/arcdps_mock/actions/runs/1251722896