### PR TITLE
don't crash with null ref if e3/e8 called in mod_init

### DIFF
--- a/arcdps_mock/main.cpp
+++ b/arcdps_mock/main.cpp
@@ -72,6 +72,9 @@ struct ArcModifiers
 // arcdps file log
 void e3(const char* pString)
 {
+	if (!combatMock) {
+		return;
+	}
 	combatMock->e3LogLine(pString);
 }
 
@@ -189,6 +192,9 @@ uint64_t e7()
 
 void e8(const char* pString)
 {
+	if (!combatMock) {
+		return;
+	}
 	if (!pString) {
 		combatMock->e8LogLine("(null)");
 	}


### PR DESCRIPTION
`combatMock` is only created after the addon's `mod_init` is called, so if `e3`/`e8` are called inside of `mod_init`, `arcdps_mock` crashes.